### PR TITLE
Add aula page with video playback

### DIFF
--- a/pages/aula.js
+++ b/pages/aula.js
@@ -1,0 +1,25 @@
+import { useRef } from 'react'
+import Link from 'next/link'
+
+export default function Aula() {
+  const videoRef = useRef(null)
+  const handlePlay = () => {
+    videoRef.current && videoRef.current.play()
+  }
+
+  return (
+    <div>
+      <h1>Aula</h1>
+      <video ref={videoRef} width="640" controls>
+        <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+        Seu navegador não suporta o elemento de vídeo.
+      </video>
+      <div>
+        <button onClick={handlePlay}>Play</button>
+      </div>
+      <div>
+        <Link href="/">Voltar</Link>
+      </div>
+    </div>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,12 @@
+import Link from 'next/link'
+
 export default function Home() {
   return (
     <div>
       <h1>Bem-vindo ao Plataforma Cursos</h1>
+      <p>
+        <Link href="/aula">Ir para a aula</Link>
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add new `/aula` route with a sample video and play button
- link to the new lesson page from the homepage

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dd460a688332b936aa71f5af0828